### PR TITLE
Feature/adi

### DIFF
--- a/app/(tabs)/my-offers.tsx
+++ b/app/(tabs)/my-offers.tsx
@@ -68,6 +68,11 @@ export default function MyOffersScreen() {
 
   const [filter, setFilter] = useState<CombinedFilter>("all");
 
+  const [openThreads, setOpenThreads] = useState<Record<string, boolean>>({});
+  const toggleThread = (requestId: string) => {
+    setOpenThreads((prev) => ({ ...prev, [requestId]: !prev[requestId] }));
+  };
+
   const [swipes, setSwipes] = useState<
     { request: RequestRow; direction: SwipeDirection; swipedAt: string }[]
   >([]);
@@ -217,6 +222,36 @@ export default function MyOffersScreen() {
     return map;
   }, [counterOffers]);
 
+  const offersByRequestId = useMemo(() => {
+    const map = new Map<string, OfferRow[]>();
+    for (const o of offers) {
+      const arr = map.get(o.request_id) ?? [];
+      arr.push(o);
+      map.set(o.request_id, arr);
+    }
+    // newest first
+    for (const [k, arr] of map) {
+      arr.sort((a, b) => +new Date(b.created_at) - +new Date(a.created_at));
+      map.set(k, arr);
+    }
+    return map;
+  }, [offers]);
+
+  const countersByOfferId = useMemo(() => {
+    const map = new Map<string, CounterOfferRow[]>();
+    for (const c of counterOffers) {
+      const arr = map.get(c.offer_id) ?? [];
+      arr.push(c);
+      map.set(c.offer_id, arr);
+    }
+    // newest first
+    for (const [k, arr] of map) {
+      arr.sort((a, b) => +new Date(b.created_at) - +new Date(a.created_at));
+      map.set(k, arr);
+    }
+    return map;
+  }, [counterOffers]);
+
   const counts = useMemo(() => {
     const all = swipes.length;
 
@@ -247,10 +282,17 @@ export default function MyOffersScreen() {
 
   const visibleBySwipe = useMemo(() => {
     if (filter === "all") return swipes;
-    if (filter === "interested")
-      return swipes.filter((s) => s.direction === "right");
+
+    if (filter === "interested") {
+      return swipes.filter(({ request, direction }) => {
+        if (direction !== "right") return false;
+        const latestOffer = latestOfferByRequestId.get(request.id);
+        return latestOffer == null; // ✅ same rule as the count
+      });
+    }
+
     return swipes.filter((s) => s.direction === "left");
-  }, [swipes, filter]);
+  }, [swipes, filter, latestOfferByRequestId]);
 
   const visible = useMemo(() => {
     // start from all swipes
@@ -476,10 +518,14 @@ export default function MyOffersScreen() {
             const latestOffer = latestOfferByRequestId.get(request.id);
             const counter = latestCounterByRequestId.get(request.id);
 
+            const requestOffers = offersByRequestId.get(request.id) ?? [];
+            const isThreadOpen = !!openThreads[request.id];
+
+            // Map "withdrawn" to "none" to satisfy the type constraint
             const offerState: OfferStatus | "none" =
               latestOffer?.status === "withdrawn"
                 ? "none"
-                : (latestOffer?.status ?? "none");
+                : ((latestOffer?.status as OfferStatus) ?? "none");
 
             const counterPending = counter?.status === "pending";
             const counterAccepted = counter?.status === "accepted";
@@ -568,39 +614,103 @@ export default function MyOffersScreen() {
                       </Text>
                     </View>
                   </View>
-
-                  {counter && (
-                    <View style={styles.counterBox}>
-                      <Text style={styles.counterTitle}>
-                        Counter-offer: €{Number(counter.price).toLocaleString()}
-                      </Text>
-                      {!!counter.message && (
-                        <Text style={styles.counterMsg} numberOfLines={3}>
-                          {counter.message}
+                  {requestOffers.length > 0 && (
+                    <View style={styles.threadHeader}>
+                      <Pressable
+                        style={styles.btnSecondary}
+                        onPress={() => toggleThread(request.id)}
+                      >
+                        <Text style={styles.threadToggleText}>
+                          {isThreadOpen
+                            ? "Hide negotiation"
+                            : `Show negotiation (${requestOffers.length})`}
                         </Text>
-                      )}
-                      <Text style={styles.counterStatus}>
-                        Status: {counter.status.toUpperCase()}
-                      </Text>
+                      </Pressable>
+                    </View>
+                  )}
 
-                      {counterPending && (
-                        <View style={styles.counterActions}>
-                          <Pressable
-                            style={styles.btnPrimary}
-                            onPress={() => acceptCounter(counter)}
+                  {isThreadOpen && requestOffers.length > 1 && (
+                    <View style={styles.threadWrap}>
+                      <Text style={styles.threadTitle}>Negotiation</Text>
+
+                      {requestOffers.map((o, idx) => {
+                        const counters = countersByOfferId.get(o.id) ?? [];
+                        const isLatest = idx === 0;
+
+                        return (
+                          <View
+                            key={o.id}
+                            style={[
+                              styles.threadNode,
+                              isLatest && styles.threadNodeLatest,
+                            ]}
                           >
-                            <Text style={styles.btnPrimaryText}>
-                              Accept counter
-                            </Text>
-                          </Pressable>
-                          <Pressable
-                            style={styles.btnSecondary}
-                            onPress={() => rejectCounter(counter)}
-                          >
-                            <Text style={styles.btnSecondaryText}>Reject</Text>
-                          </Pressable>
-                        </View>
-                      )}
+                            <View style={styles.offerRow}>
+                              <Text style={styles.offerMain}>
+                                Offer: €{Number(o.price).toLocaleString()}
+                              </Text>
+                              <Text style={styles.offerMeta}>
+                                {o.status.toUpperCase()} •{" "}
+                                {new Date(o.created_at).toLocaleString()}
+                              </Text>
+                            </View>
+
+                            {!!o.description && (
+                              <Text style={styles.offerDesc} numberOfLines={2}>
+                                {o.description}
+                              </Text>
+                            )}
+
+                            {counters.map((c) => {
+                              const counterPending = c.status === "pending";
+
+                              return (
+                                <View key={c.id} style={styles.counterNode}>
+                                  <Text style={styles.counterMain}>
+                                    ↳ Counter: €
+                                    {Number(c.price).toLocaleString()}
+                                  </Text>
+
+                                  {!!c.message && (
+                                    <Text
+                                      style={styles.counterMsg}
+                                      numberOfLines={3}
+                                    >
+                                      {c.message}
+                                    </Text>
+                                  )}
+
+                                  <Text style={styles.counterMeta}>
+                                    {c.status.toUpperCase()} •{" "}
+                                    {new Date(c.created_at).toLocaleString()}
+                                  </Text>
+
+                                  {isLatest && counterPending && (
+                                    <View style={styles.counterActions}>
+                                      <Pressable
+                                        style={styles.btnPrimary}
+                                        onPress={() => acceptCounter(c)}
+                                      >
+                                        <Text style={styles.btnPrimaryText}>
+                                          Accept counter
+                                        </Text>
+                                      </Pressable>
+                                      <Pressable
+                                        style={styles.btnSecondary}
+                                        onPress={() => rejectCounter(c)}
+                                      >
+                                        <Text style={styles.btnSecondaryText}>
+                                          Reject
+                                        </Text>
+                                      </Pressable>
+                                    </View>
+                                  )}
+                                </View>
+                              );
+                            })}
+                          </View>
+                        );
+                      })}
                     </View>
                   )}
 
@@ -639,6 +749,11 @@ export default function MyOffersScreen() {
                         <Text style={styles.statusText}>
                           COUNTER-OFFER ACCEPTED
                         </Text>
+                      </View>
+                    )}
+                    {effectiveState === "withdrawn" && (
+                      <View style={[styles.statusPill, styles.statusWithdrawn]}>
+                        <Text style={styles.statusText}>WITHDRAWN</Text>
                       </View>
                     )}
                   </View>
@@ -800,6 +915,23 @@ const styles = StyleSheet.create({
   pillSkipped: { backgroundColor: theme.border, borderColor: theme.border },
   pillText: { fontSize: 12, fontWeight: "900", color: theme.primaryText },
 
+  myOfferBox: {
+    marginTop: 10,
+    padding: 10,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: theme.border,
+    backgroundColor: theme.surface,
+  },
+  myOfferTitle: { fontWeight: "900", color: theme.primaryText },
+  myOfferDesc: { marginTop: 4, color: theme.secondaryText, fontWeight: "700" },
+  myOfferMeta: {
+    marginTop: 6,
+    color: theme.secondaryText,
+    fontWeight: "700",
+    fontSize: 12,
+  },
+
   counterBox: {
     marginTop: 12,
     borderWidth: 1,
@@ -810,13 +942,11 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   counterTitle: { fontWeight: "900", color: theme.primaryText },
-  counterMsg: { color: theme.secondaryText, lineHeight: 18 },
   counterStatus: {
     fontWeight: "900",
     color: theme.secondaryText,
     fontSize: 12,
   },
-  counterActions: { flexDirection: "row", gap: 10, marginTop: 8 },
 
   statusRow: { marginTop: 12 },
   statusPill: { paddingVertical: 8, paddingHorizontal: 10, borderRadius: 14 },
@@ -824,6 +954,8 @@ const styles = StyleSheet.create({
   statusPending: { backgroundColor: theme.accentSoft },
   statusAccepted: { backgroundColor: theme.successSoft },
   statusRejected: { backgroundColor: theme.dangerSoft },
+  statusWithdrawn: { backgroundColor: theme.dangerSoft },
+
   statusText: { fontWeight: "900", fontSize: 12, color: theme.primaryText },
 
   actionRow: { marginTop: 12, gap: 10 },
@@ -886,4 +1018,41 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
   },
   actionText: { color: "white", fontWeight: "900", fontSize: 12 },
+
+  threadHeader: { marginTop: 10 },
+  threadToggle: { paddingVertical: 6 },
+  threadToggleText: { fontWeight: "900", color: theme.primaryText },
+
+  threadWrap: { marginTop: 10, gap: 10 },
+  threadTitle: { fontWeight: "900", color: theme.primaryText },
+
+  threadNode: {
+    borderLeftWidth: 3,
+    borderLeftColor: theme.border,
+    paddingLeft: 10,
+    paddingVertical: 8,
+    borderRadius: 12,
+    backgroundColor: theme.bg,
+  },
+  threadNodeLatest: { borderLeftColor: theme.primary },
+
+  offerRow: { gap: 2 },
+  offerMain: { fontWeight: "900", color: theme.primaryText },
+  offerMeta: { fontSize: 12, color: theme.secondaryText, fontWeight: "700" },
+  offerDesc: { marginTop: 6, color: theme.secondaryText, lineHeight: 18 },
+
+  counterNode: {
+    marginTop: 10,
+    marginLeft: 6,
+    padding: 10,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: theme.border,
+    backgroundColor: theme.surface,
+    gap: 4,
+  },
+  counterMain: { fontWeight: "900", color: theme.primaryText },
+  counterMsg: { color: theme.secondaryText, lineHeight: 18 },
+  counterMeta: { fontSize: 12, color: theme.secondaryText, fontWeight: "700" },
+  counterActions: { flexDirection: "row", gap: 10, marginTop: 8 },
 });

--- a/app/(tabs)/my-offers.tsx
+++ b/app/(tabs)/my-offers.tsx
@@ -362,7 +362,7 @@ export default function MyOffersScreen() {
 
     const { error: oErr } = await supabase
       .from("offers")
-      .update({ status: "accepted", price: counter.price })
+      .update({ status: "accepted" })
       .eq("id", counter.offer_id);
 
     if (oErr) return Alert.alert("Error", oErr.message);
@@ -519,7 +519,7 @@ export default function MyOffersScreen() {
             const counter = latestCounterByRequestId.get(request.id);
 
             const requestOffers = offersByRequestId.get(request.id) ?? [];
-            const isThreadOpen = !!openThreads[request.id];
+            const isThreadOpen = openThreads[request.id] !== false;
 
             // Map "withdrawn" to "none" to satisfy the type constraint
             const offerState: OfferStatus | "none" =
@@ -629,12 +629,15 @@ export default function MyOffersScreen() {
                     </View>
                   )}
 
-                  {isThreadOpen && requestOffers.length > 1 && (
+                  {isThreadOpen && requestOffers.length > 0 && (
                     <View style={styles.threadWrap}>
                       <Text style={styles.threadTitle}>Negotiation</Text>
 
                       {requestOffers.map((o, idx) => {
                         const counters = countersByOfferId.get(o.id) ?? [];
+                        const acceptedCounter =
+                          counters.find((x) => x.status === "accepted") ?? null; // OK even newest-first
+
                         const isLatest = idx === 0;
 
                         return (
@@ -645,21 +648,54 @@ export default function MyOffersScreen() {
                               isLatest && styles.threadNodeLatest,
                             ]}
                           >
-                            <View style={styles.offerRow}>
-                              <Text style={styles.offerMain}>
-                                Offer: €{Number(o.price).toLocaleString()}
-                              </Text>
+                            {isLatest && (
+                              <View style={styles.currentBadge}>
+                                <Text style={styles.currentBadgeText}>
+                                  CURRENT
+                                </Text>
+                              </View>
+                            )}
+
+                            <View style={styles.offerHeaderRow}>
+                              {acceptedCounter ? (
+                                // Vinted style (only when counter accepted)
+                                <View style={styles.offerCompareRow}>
+                                  <Text style={styles.oldOfferText}>
+                                    €{Number(o.price).toLocaleString()} •
+                                    REJECTED
+                                  </Text>
+
+                                  <Text style={styles.arrowText}>→</Text>
+
+                                  <Text style={styles.newOfferText}>
+                                    €
+                                    {Number(
+                                      acceptedCounter.price,
+                                    ).toLocaleString()}{" "}
+                                    • ACCEPTED
+                                  </Text>
+                                </View>
+                              ) : (
+                                // Normal style (always show status)
+                                <Text
+                                  style={[
+                                    styles.offerMain,
+                                    (o.status === "rejected" ||
+                                      o.status === "withdrawn") &&
+                                      styles.offerMainBad,
+                                    o.status === "accepted" &&
+                                      styles.offerMainGood,
+                                  ]}
+                                >
+                                  €{Number(o.price).toLocaleString()} •{" "}
+                                  {o.status.toUpperCase()}
+                                </Text>
+                              )}
+
                               <Text style={styles.offerMeta}>
-                                {o.status.toUpperCase()} •{" "}
                                 {new Date(o.created_at).toLocaleString()}
                               </Text>
                             </View>
-
-                            {!!o.description && (
-                              <Text style={styles.offerDesc} numberOfLines={2}>
-                                {o.description}
-                              </Text>
-                            )}
 
                             {counters.map((c) => {
                               const counterPending = c.status === "pending";
@@ -667,7 +703,8 @@ export default function MyOffersScreen() {
                               return (
                                 <View key={c.id} style={styles.counterNode}>
                                   <Text style={styles.counterMain}>
-                                    ↳ Counter: €
+                                    ↳ {request.profiles?.email ?? "unknown"} 's
+                                    counter offer: €
                                     {Number(c.price).toLocaleString()}
                                   </Text>
 
@@ -681,7 +718,19 @@ export default function MyOffersScreen() {
                                   )}
 
                                   <Text style={styles.counterMeta}>
-                                    {c.status.toUpperCase()} •{" "}
+                                    <Text
+                                      style={{
+                                        fontWeight: "900",
+                                        color:
+                                          o.status === "rejected"
+                                            ? "#dc2626" // red
+                                            : o.status === "withdrawn"
+                                              ? "#dc2626" // red for withdrawn too (optional)
+                                              : "#16a34a", // green for accepted / pending
+                                      }}
+                                    >
+                                      {c.status.toUpperCase()} •{" "}
+                                    </Text>
                                     {new Date(c.created_at).toLocaleString()}
                                   </Text>
 
@@ -1034,12 +1083,16 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     backgroundColor: theme.bg,
   },
-  threadNodeLatest: { borderLeftColor: theme.primary },
 
   offerRow: { gap: 2 },
   offerMain: { fontWeight: "900", color: theme.primaryText },
   offerMeta: { fontSize: 12, color: theme.secondaryText, fontWeight: "700" },
-  offerDesc: { marginTop: 6, color: theme.secondaryText, lineHeight: 18 },
+  offerDesc: {
+    marginTop: 6,
+    marginBottom: 6,
+    color: theme.secondaryText,
+    lineHeight: 18,
+  },
 
   counterNode: {
     marginTop: 10,
@@ -1051,6 +1104,45 @@ const styles = StyleSheet.create({
     backgroundColor: theme.surface,
     gap: 4,
   },
+
+  threadNodeLatest: {
+    borderLeftColor: theme.primary,
+    backgroundColor: "#f0f9ff",
+  },
+
+  currentBadge: {
+    alignSelf: "flex-start",
+    backgroundColor: theme.primary,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 999,
+    marginBottom: 4,
+  },
+
+  currentBadgeText: {
+    color: "white",
+    fontWeight: "900",
+    fontSize: 10,
+  },
+  offerHeaderRow: { gap: 6 },
+  offerCompareRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+
+  offerMainGood: { color: "#16a34a" },
+  offerMainBad: { color: "#dc2626" },
+
+  oldOfferText: {
+    fontWeight: "900",
+    color: "#dc2626",
+    textDecorationLine: "line-through",
+  },
+  arrowText: { fontWeight: "900", color: theme.secondaryText },
+  newOfferText: { fontWeight: "900", color: "#16a34a" },
+
   counterMain: { fontWeight: "900", color: theme.primaryText },
   counterMsg: { color: theme.secondaryText, lineHeight: 18 },
   counterMeta: { fontSize: 12, color: theme.secondaryText, fontWeight: "700" },

--- a/app/(tabs)/my-offers.tsx
+++ b/app/(tabs)/my-offers.tsx
@@ -19,9 +19,6 @@ type OfferStatus = "pending" | "accepted" | "rejected";
 type OfferStatusDb = OfferStatus | "withdrawn";
 type CounterStatus = "pending" | "accepted" | "rejected" | "withdrawn";
 
-type Filter = "all" | "interested" | "skipped";
-type OfferViewFilter = "active" | "withdrawn" | "all";
-
 type RequestRow = {
   id: string;
   user_id: string;
@@ -62,11 +59,17 @@ export default function MyOffersScreen() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
 
-  const [filter, setFilter] = useState<Filter>("all");
-  const [offerView, setOfferView] = useState<OfferViewFilter>("all");
+  type CombinedFilter =
+    | "all"
+    | "interested"
+    | "skipped"
+    | "active"
+    | "withdrawn";
+
+  const [filter, setFilter] = useState<CombinedFilter>("all");
 
   const [swipes, setSwipes] = useState<
-    Array<{ request: RequestRow; direction: SwipeDirection; swipedAt: string }>
+    { request: RequestRow; direction: SwipeDirection; swipedAt: string }[]
   >([]);
 
   const [offers, setOffers] = useState<OfferRow[]>([]);
@@ -127,17 +130,22 @@ export default function MyOffersScreen() {
           ? row.requests[0]
           : row.requests;
         if (!req) return null;
+
         return {
           request: req as RequestRow,
           direction: row.direction as SwipeDirection,
           swipedAt: row.created_at as string,
         };
       })
-      .filter(Boolean) as Array<{
-      request: RequestRow;
-      direction: SwipeDirection;
-      swipedAt: string;
-    }>;
+      .filter(
+        (
+          x,
+        ): x is {
+          request: RequestRow;
+          direction: SwipeDirection;
+          swipedAt: string;
+        } => x !== null,
+      );
 
     setSwipes(normalizedSwipes);
 
@@ -211,10 +219,17 @@ export default function MyOffersScreen() {
 
   const counts = useMemo(() => {
     const all = swipes.length;
-    const interested = swipes.filter((s) => s.direction === "right").length;
+
+    const interested = swipes.filter(({ request, direction }) => {
+      if (direction !== "right") return false;
+      const latestOffer = latestOfferByRequestId.get(request.id);
+      return latestOffer == null; // ✅ only if no offer ever sent
+    }).length;
+
     const skipped = swipes.filter((s) => s.direction === "left").length;
+
     return { all, interested, skipped };
-  }, [swipes]);
+  }, [swipes, latestOfferByRequestId]);
 
   const offerViewCounts = useMemo(() => {
     let active = 0;
@@ -238,14 +253,37 @@ export default function MyOffersScreen() {
   }, [swipes, filter]);
 
   const visible = useMemo(() => {
-    if (offerView === "all") return visibleBySwipe;
+    // start from all swipes
+    let base = swipes;
 
-    return visibleBySwipe.filter(({ request }) => {
-      const latestOffer = latestOfferByRequestId.get(request.id);
-      if (offerView === "withdrawn") return latestOffer?.status === "withdrawn";
-      return latestOffer != null && latestOffer.status !== "withdrawn";
-    });
-  }, [visibleBySwipe, offerView, latestOfferByRequestId]);
+    // 1) swipe-based filters
+    if (filter === "interested") {
+      base = base.filter(({ request, direction }) => {
+        if (direction !== "right") return false;
+        const latestOffer = latestOfferByRequestId.get(request.id);
+        return latestOffer == null; // <-- key change: no offer ever sent
+      });
+    }
+
+    if (filter === "skipped") base = base.filter((s) => s.direction === "left");
+
+    // 2) offer-based filters (needs latestOfferByRequestId)
+    if (filter === "withdrawn") {
+      base = base.filter(({ request }) => {
+        const latestOffer = latestOfferByRequestId.get(request.id);
+        return latestOffer?.status === "withdrawn";
+      });
+    }
+
+    if (filter === "active") {
+      base = base.filter(({ request }) => {
+        const latestOffer = latestOfferByRequestId.get(request.id);
+        return latestOffer != null && latestOffer.status !== "withdrawn";
+      });
+    }
+
+    return base;
+  }, [swipes, filter, latestOfferByRequestId]);
 
   const openCreateOffer = (requestId: string) => {
     router.push({
@@ -374,47 +412,32 @@ export default function MyOffersScreen() {
         <View style={styles.filters}>
           <FilterBtn
             label={`All (${counts.all})`}
-            active={filter === "all" && offerView === "all"}
-            onPress={() => {
-              setFilter("all");
-              setOfferView("all");
-            }}
+            active={filter === "all"}
+            onPress={() => setFilter("all")}
           />
 
           <FilterBtn
             label={`Interested (${counts.interested})`}
-            active={filter === "interested" && offerView === "all"}
-            onPress={() => {
-              setFilter("interested");
-              setOfferView("all");
-            }}
+            active={filter === "interested"}
+            onPress={() => setFilter("interested")}
           />
 
           <FilterBtn
             label={`Active (${offerViewCounts.active})`}
-            active={filter === "all" && offerView === "active"}
-            onPress={() => {
-              setFilter("all");
-              setOfferView("active");
-            }}
+            active={filter === "active"}
+            onPress={() => setFilter("active")}
           />
 
           <FilterBtn
             label={`Skipped (${counts.skipped})`}
-            active={filter === "skipped" && offerView === "all"}
-            onPress={() => {
-              setFilter("skipped");
-              setOfferView("all");
-            }}
+            active={filter === "skipped"}
+            onPress={() => setFilter("skipped")}
           />
 
           <FilterBtn
             label={`Withdrawn (${offerViewCounts.withdrawn})`}
-            active={filter === "all" && offerView === "withdrawn"}
-            onPress={() => {
-              setFilter("all");
-              setOfferView("withdrawn");
-            }}
+            active={filter === "withdrawn"}
+            onPress={() => setFilter("withdrawn")}
           />
         </View>
       </View>

--- a/app/(tabs)/my-requests.tsx
+++ b/app/(tabs)/my-requests.tsx
@@ -14,7 +14,18 @@ import {
 import Swipeable from "react-native-gesture-handler/Swipeable";
 import { supabase } from "../../src/lib/supabase";
 
-type Filter = "all" | "active" | "closed";
+type Filter = "all" | "active" | "matched" | "closed";
+
+function getStatusLabel(status: "active" | "matched" | "closed") {
+  switch (status) {
+    case "active":
+      return "OPEN";
+    case "matched":
+      return "NEGOTIATING";
+    case "closed":
+      return "CLOSED";
+  }
+}
 
 type RequestRow = {
   id: string;
@@ -188,16 +199,15 @@ export default function MyRequestsScreen() {
 
   const counts = useMemo(() => {
     const all = requests.length;
-    const active = requests.filter((r) => r.status !== "closed").length;
+    const active = requests.filter((r) => r.status === "active").length;
+    const matched = requests.filter((r) => r.status === "matched").length;
     const closed = requests.filter((r) => r.status === "closed").length;
-    return { all, active, closed };
+    return { all, active, matched, closed };
   }, [requests]);
 
   const filtered = useMemo(() => {
     if (filter === "all") return requests;
-    if (filter === "closed")
-      return requests.filter((r) => r.status === "closed");
-    return requests.filter((r) => r.status !== "closed");
+    return requests.filter((r) => r.status === filter);
   }, [requests, filter]);
 
   const confirmDelete = (req: RequestRow) => {
@@ -315,35 +325,18 @@ export default function MyRequestsScreen() {
                 </View>
               )}
 
-              {/* ✅ NEW: withdrawn badge */}
-              {hasWithdrawnOffers && (
-                <View style={styles.withdrawnPill}>
-                  <Text style={styles.withdrawnPillText}>
-                    {offerCounts.withdrawn} withdrawn
-                  </Text>
-                </View>
-              )}
-
-              {hasAcceptedDeal && (
-                <View style={styles.dealPill}>
-                  <Text style={styles.dealPillText}>DEAL</Text>
-                </View>
-              )}
-
               <View
                 style={[
                   styles.statusPill,
                   item.status === "active"
-                    ? styles.statusActive
+                    ? styles.statusOpen
                     : item.status === "matched"
-                      ? styles.statusMatched
+                      ? styles.statusNegotiating
                       : styles.statusClosed,
                 ]}
               >
                 <Text style={styles.statusText}>
-                  {item.status === "matched"
-                    ? "MATCHED"
-                    : item.status.toUpperCase()}
+                  {getStatusLabel(item.status)}
                 </Text>
               </View>
             </View>
@@ -453,11 +446,19 @@ export default function MyRequestsScreen() {
             active={filter === "all"}
             onPress={() => setFilter("all")}
           />
+
           <FilterBtn
-            label={`Active (${counts.active})`}
+            label={`Open (${counts.active})`}
             active={filter === "active"}
             onPress={() => setFilter("active")}
           />
+
+          <FilterBtn
+            label={`Negotiating (${counts.matched})`}
+            active={filter === "matched"}
+            onPress={() => setFilter("matched")}
+          />
+
           <FilterBtn
             label={`Closed (${counts.closed})`}
             active={filter === "closed"}
@@ -645,6 +646,12 @@ const styles = StyleSheet.create({
   statusMatched: { backgroundColor: "#FEF9C3", borderColor: "#F59E0B" },
   statusClosed: { backgroundColor: theme.border, borderColor: theme.border },
   statusText: { fontSize: 12, fontWeight: "900", color: theme.primaryText },
+  statusOpen: {
+    backgroundColor: "#2f855a", // or whatever you use for "active"
+  },
+  statusNegotiating: {
+    backgroundColor: "#805ad5", // pick any color you like
+  },
 
   title: {
     marginTop: 10,


### PR DESCRIPTION
- Simplified My Offers filtering to match mental model:
  interested → active → withdrawn
- Unified offer status into a single pill per request
- Added negotiation thread (tree view) showing full offer/counter history
- Made negotiation thread open by default and collapsible per request
- Highlighted newest offer round and marked it as CURRENT
- Moved Chat button to appear directly under the accepted offer or counter
- Implemented Vinted-style offer comparison:
  - strike through rejected offer price
  - show accepted counter price alongside
- Preserved original offer price when accepting counters
- Fixed issue where offer price was overwritten by counter acceptance
- Ensured offer status is always visible for direct accept/reject cases
- Improved visual hierarchy and clarity of accepted / rejected states
